### PR TITLE
Add L2 pools to coinRegistry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pontem/coins-registry",
-  "version": "2.1.35",
+  "version": "2.1.36",
   "description": "Liquidswap & Pontem Wallet coins & pools registry",
   "main": "src/index.js",
   "scripts": {

--- a/src/pools.json
+++ b/src/pools.json
@@ -203,9 +203,23 @@
     "networkId": 2
   },
   {
-    "coinX": "0x1::native_coin::NativeCoin",
-    "coinY": "0x45a6dce5d868431d7f0c224a0122e64372eeb1697309529c9aaa94a97e9d331e::coins::USDT",
+    "coinX": "0x45a6dce5d868431d7f0c224a0122e64372eeb1697309529c9aaa94a97e9d331e::coins::USDT",
+    "coinY": "0x1::native_coin::NativeCoin",
     "curve": "unstable",
+    "contract": 0.5,
+    "networkId": 5
+  },
+  {
+    "coinX": "0x45a6dce5d868431d7f0c224a0122e64372eeb1697309529c9aaa94a97e9d331e::coins::BTC",
+    "coinY": "0x1::native_coin::NativeCoin",
+    "curve": "unstable",
+    "contract": 0.5,
+    "networkId": 5
+  },
+  {
+    "coinX": "0x45a6dce5d868431d7f0c224a0122e64372eeb1697309529c9aaa94a97e9d331e::coins::BTC",
+    "coinY": "0x1::native_coin::NativeCoin",
+    "curve": "stable",
     "contract": 0.5,
     "networkId": 5
   }


### PR DESCRIPTION
![Screenshot 2023-12-19 040920](https://github.com/pontem-network/coins-registry/assets/25219331/723250d6-33ff-4083-8c64-fa0d19570bb1)

Added L2 pools BTC-ETH stable and uncorrelated to pools json.
Checked locally, works smoothly. 
Also replaced order on first pool ETH - USDT. 